### PR TITLE
BCN: fix server fatal error with complete reconnection

### DIFF
--- a/bcn/index.js
+++ b/bcn/index.js
@@ -1,15 +1,16 @@
 import GetAllChartData from "./src/index.js";
 
 const cmdArgs = process.argv.slice(2);
-const baseHTMLFile = cmdArgs.length ? cmdArgs[0] : 'cache';
-const baseJSONFile = cmdArgs.length ? cmdArgs[1] : 'dest';
+const baseHTMLFile = cmdArgs.length     ? cmdArgs[0] : 'cache';
+const baseJSONFile = cmdArgs.length > 1 ? cmdArgs[1] : 'dest';
+const disableCache = cmdArgs.length > 2 ? cmdArgs[2] : false;
 
 console.log(process.env.NODE_ENV);
 
 try {
 
   console.log("::group::Downloading log");
-  const getter = new GetAllChartData({baseHTMLFile, baseJSONFile});
+  const getter = new GetAllChartData({baseHTMLFile, baseJSONFile, disableCache});
   const { result, errors, counters }  = await getter.get();
   console.log("::endgroup::");
 

--- a/bcn/src/Socket.js
+++ b/bcn/src/Socket.js
@@ -14,7 +14,10 @@ import fetch from 'cross-fetch';
 async function* makeTextFetchLineIterator(fileURL, options) {
   const utf8Decoder = new TextDecoder('utf-8');
   const response = await fetch(fileURL, options)
-    .catch(err => console.log("Iterator: Fetch: Error:", err));
+    .catch(err => {
+      console.log("Fetch Iterator: Fetch: Error:", err);
+      throw err
+    });
   console.log("Response:",response);
   const reader = response.body;
 
@@ -22,12 +25,16 @@ async function* makeTextFetchLineIterator(fileURL, options) {
 
   let remaining = '';
   for await (const bytes of reader) {
+
     const chunk = remaining + (bytes ? utf8Decoder.decode(bytes) : '');
     console.log("Chunk received");
     let startIndex = 0;
     let result;
+
     while(result = re.exec(chunk)) {
       const next = chunk.substring(startIndex, result.index);
+
+      // If stream end is detected
       if (reader.done && (
             re.lastIndex === chunk.length - 1 || // No more chars
             result[0] === '\n'                   // Only '\n' remaining
@@ -38,19 +45,26 @@ async function* makeTextFetchLineIterator(fileURL, options) {
         // If `yield` returns something, it's a user parameter passed through `next`
         // We use it to cleanly close the stream when called as `next(true)`
         const close = yield next;
+
         if (close) {
           reader.end();
           reader.destroy();
           throw new Error("Generator: aborted");
         }
       }
+
       startIndex = re.lastIndex;
     }
+
+    // Save remaining (not consumed) data
     remaining = chunk.substr(startIndex);
+
+    // Restart newlines Regexp parser
     startIndex = re.lastIndex = 0;
   }
+
+  // Last line didn't end in a newline char
   if (remaining.length) {
-    // Last line didn't end in a newline char
     return remaining;
   }
 }
@@ -114,11 +128,13 @@ class Socket {
         console.log("Connect: Wait for next line");
         const line = await this.iterable.next();
         console.log("Connect: Received line: ", line);
+
         if (testConnected(line.value)) {
           console.log("Connect: Received start!");
           this.done = false;
           return;
         }
+
         if (line.done) {
           throw new Error("Connect: Backend disconnected");
         }
@@ -139,7 +155,6 @@ class Socket {
     this.controller = new AbortController();
 
     console.log("Consume remaining iterable and ask to close.");
-
     try {
       await this.iterable.next(true);
     } catch(err) { }
@@ -147,6 +162,114 @@ class Socket {
     this.done = undefined;
 
     console.log("Socket: All done closing.");
+  }
+
+  // Parses a message raw response
+  // Before parsing, tests is message is applicable to parsing message kind
+  // If applies, will returns JSON.parse results, or throws error on JSON parse error
+  parseMessageStr = (value, regexp) => {
+    // Parse "a[...]" or "c[...]" or "4F#0|m|{...}"
+    const result = regexp.exec(value);
+
+    // If found, look for Array of data
+    if (result?.length) {
+      // Parse multiple data in a possible single message array
+      const [,dataStr] = result;
+
+      try {
+        return JSON.parse(dataStr)
+      } catch(err) {
+        console.warn("Consume: Error parsing JSON: ", {err, dataStr, result});
+        throw err;
+      }
+    }
+
+    return false;
+  }
+
+  // Parses an error message received by consume
+  // If possible, tries to solve the situation
+  // If not possible, throws fatal error
+  parseConsumeError = async (value) => {
+    // Connection was completely restarted
+    // We need to send the initial requests
+    if (value === 'o') {
+      console.log(`Complete connection restart detected. Sending initial commands (${this.initialRequests.length})...`);
+      await this.sendInitialRequests();
+      return false;
+    }
+
+    // Parse "c[...]"
+    const dataArray = this.parseMessageStr(value, /^c(\[.*\])$/);
+
+    // There was an error sent from server
+    if (dataArray !== false) {
+      const [code, error] = dataArray;
+
+      console.warn(`Detected error from server: ${code} - ${error}`);
+
+      // Unable to open connection
+      if (code === 4705) {
+        // We need a complete new connection
+        console.log(`Complete connection restart forced.`);
+        await this.close();
+        this.generateConnectionString();
+        await this.connect();
+
+        return false;
+      }
+      // Unhandled connection error
+      else {
+        throw new Error(`Connection FATAL error: ${code} - ${error}`);
+      }
+    }
+
+    // We can continue consuming normally
+    return true;
+  }
+
+  // Tries to parse a consume raw response
+  // - On success, returns object response
+  // - If not array response (keepalive/ACK/error), returns false (wait for next or possible error)
+  // - If array but without object (lack examples) or with a not validated
+  //   object (busy,recalculating,recalculated, i...), returns null
+  parseConsumeResponse = (value, validate) => {
+
+    // Parse "a[...]"
+    const dataArray = this.parseMessageStr(value, /^a(\[.*\])$/);
+
+    // If found, look for Array of data
+    if (dataArray !== false) {
+
+      // For each data, look for quoted text with a JSON prefixed with some code
+      for (const data of dataArray) {
+
+        // Original sockjs code evals the string to get the value
+        const parsed = this.parseMessageStr(data, /^\w+#\w+\|m\|(\{.*\})$/);
+       
+        // If found, parse the JSON part and return the resulting object
+        if (parsed !== false) {
+          console.log("Correct result found in response. Message received:", {parsed});
+
+          // Test if request' final response validation passes
+          if (validate(parsed)) {
+            console.log("Final message received");
+            return parsed;
+          }
+          else {
+            console.log("Not validated");
+          }
+        }
+        else {
+          console.log("Not matched object:",{data});
+        }
+      }
+    }
+    else {
+      return false
+    }
+
+    return null;
   }
 
   // Consume messages in iterator, under demmand
@@ -164,92 +287,37 @@ class Socket {
       }
     }
 
-    console.log("Consume: Received:",{
+    console.log("Consume: Received:", {
       done,
       value: value?.substring(0,80),
     });
 
-    // Parse "a[...]"
-    const reUnArray = /^a(\[.*\])$/;
-    const resultUnArray = reUnArray.exec(value);
+    // Tries to parse and validate a correct message string
+    const parsedResponse = this.parseConsumeResponse(value, validate);
 
-    // If found, look for Array of data
-    if (resultUnArray?.length) {
-      // Parse multiple data in a single message array
-      const [,dataArrayStr] = resultUnArray;
-      const dataArray = JSON.parse(dataArrayStr);
-
-      // For each data, look for quoted text with a JSON prefixed with some code
-      for (const data of dataArray) {
-        const re = /^\w+#\w+\|m\|(\{.*\})$/;
-        const result = re.exec(data);
-       
-        // If found, parse the JSON part and return the resulting object
-        if (result?.length) {
-          console.log("Correct result found in response");
-       
-          // Original sockjs code evals the string to get the value
-          const [,content] = result;
-          let parsed;
-          try {
-            parsed = JSON.parse( content );
-          } catch(err) {
-            console.warn("Consume: Error parsing JSON: ", {err, content, parsed});
-            throw err;
-          }
-       
-          console.log("Message received:", {parsed});
-       
-          // Test if request' final response validation passes
-          if (validate(parsed)) {
-            console.log("Final message received");
-            return parsed;
-          }
-          else {
-            console.log("Not validated");
-          }
-        }
-        else {
-          console.log("Not matched object:",{re,data,result});
-        }
-      }
+    // If parsed evaluates to true (an object), return valid response
+    // Other possible responses are:
+    // - null: transactional message: keep trying
+    // - false: error detected, try to handle
+    // - throw error: Error parsing one of the two JSON strings
+    if (parsedResponse) {
+      return parsedResponse;
     }
-    else {
-      console.log("Not matched Array:",{reUnArray,resultUnArray,received:{done,value}});
 
-      // Parse "c[...]"
-      const reUnException = /^c(\[.*\])$/;
-      const resultUnException = reUnException.exec(value);
+    // If parsed is exactly false, it is an error message
+    // Try to handle it or rethrow if couldn't
+    else if (parsedResponse === false) {
+      console.log("Not matched Array:", {received: {done, value}});
 
-      // Connection was completely restarted
-      // We need to send the initial requests
-      if (value === 'o') {
-        console.log(`Complete connection restart detected. Sending initial commands (${this.initialRequests.length})...`);
-        await this.sendInitialRequests();
-        return false;
-      }
-      // There was an error sent from server
-      else if (resultUnException?.length) {
-        const [,dataArrayStr] = resultUnException;
-        const dataArray = JSON.parse(dataArrayStr);
-        const [code, error] = dataArray;
+      const parsedError = await this.parseConsumeError(value);
 
-        console.warn(`Detected error from server: ${code} - ${error}`);
-
-        // Unable to open connection
-        if (code === 4705) {
-          // We need a complete new connection
-          console.log(`Complete connection restart forced.`);
-          await this.close();
-          this.generateConnectionString();
-          await this.connect();
-
-          return false;
-        }
-        // Unable to open connection
-        else {
-          throw new Error(`Connection error: ${code} - ${error}`);
-        }
+      // Only true is a good result
+      // Other results:
+      //  - false: Need to resend query
+      //  - throw error: Final fatal error: Something is very wrong
+      //  - throw error: Error parsing the JSON string
+      if (parsedError !== true) {
+        return parsedError;
       }
     }
 
@@ -258,9 +326,9 @@ class Socket {
     return await this.consume(validate);
   }
 
+  // Try to connect 3 times
+  // Re-throw the error on the last
   connectRetry = async (count=3) => {
-    // Try to connect 3 times
-    // Re-throw the error on the last
     try {
       await this.connect();
     } catch(err) {
@@ -271,10 +339,11 @@ class Socket {
       }
 
       // Re-try
-      await this.connectRetry(count-1);
+      await this.connectRetry(count - 1);
     }
   }
 
+  // Handle when connection is in bad/temporal state
   ensureConnection = async () => {
     // If the backend has disconnected, re-connect
     if (this.done === true || this.done === undefined) {
@@ -287,9 +356,10 @@ class Socket {
       console.log("Consume: Backend reconnecting. Wait for it.");
       await this.done;
     }
-
   }
 
+  // Sends to server the requests to correctly initiate the session
+  // Used on hard reconnections
   sendInitialRequests = async () => {
     for (const request of this.initialRequests) {
       const {payload, validate} = request;
@@ -327,7 +397,7 @@ class Socket {
 
     } catch(err) {
 
-      console.log("Send: Error consuming:", err);
+      console.log("Send: Error consuming. Try to do soft reconnection.", err);
       await this.connect();
       result = await this.consume(validate);
 

--- a/bcn/src/index.js
+++ b/bcn/src/index.js
@@ -37,9 +37,10 @@ class GetAllData {
     messages: [],
   };
 
-  constructor({ baseHTMLFile, baseJSONFile }) {
+  constructor({ baseHTMLFile, baseJSONFile, disableCache }) {
     this.baseHTMLFile = baseHTMLFile;
     this.baseJSONFile = baseJSONFile;
+    this.disableCache = disableCache;
   }
 
   // Treat data errors as warnings:
@@ -85,7 +86,9 @@ class GetAllData {
     // Try to read data from cached file
     try {
 
-      //throw new Error("Cache temporarily disconnected");
+      if (this.disableCache) {
+        throw new Error("Cache temporarily disabled");
+      }
 
       // If forced, throw error to jump to catch block
       if (request.force) {
@@ -227,3 +230,4 @@ class GetAllData {
 }
 
 export default GetAllData;
+export {hashStr}; // For unit testing

--- a/bcn/src/index.js
+++ b/bcn/src/index.js
@@ -61,14 +61,14 @@ class GetAllData {
   }
 
   // Handles a single request process
-  handleRequest = async ({query, validate}) => {
+  handleRequest = async ({query, validate, force}) => {
 
     // Send request to server:
     // - It may need to auto-(re)connect the socket
     // - It may need to re-send the request
     // - Looks for correct results (JSON object)
     // - Validates with request validate callback
-    return await this.sock.send( query, validate );
+    return await this.sock.send(query, validate, force);
   }
 
   // Cache responses to files
@@ -80,32 +80,34 @@ class GetAllData {
     const hash = hashStr(query);
     const file = `${this.baseHTMLFile}/response.json?${hash}`;
 
+    let data;
+
     // Try to read data from cached file
     try {
+
+      //throw new Error("Cache temporarily disconnected");
 
       // If forced, throw error to jump to catch block
       if (request.force) {
         throw new Error("Forced request download");
       }
 
-      const data = await fs.readFile(file, 'utf8');
+      const dataStr = await fs.readFile(file, 'utf8');
 
       // Parse the JSON into a JS object and, then, the request parse
-      const parsed = request.parse( JSON.parse(data), this.parseDataErrors );
+      data = JSON.parse(dataStr);
 
       console.warn(`Request read from file '${file}': '${hash}'`);
 
       // Increment read counter only if it was ok
       this.counters.read++;
 
-      return parsed
-
     } catch (err) {
 
       console.log(`The file '${file}' was not read from cache: fetch '${hash}':`, err.message);
 
       // Try to download a fresh copy from web
-      const data = await this.handleRequest({query, ...restRequest});
+      data = await this.handleRequest({query, ...restRequest});
 
       // Once downloaded, save page into cache file
       console.log(`Save response from '${hash}' to file '${file}'.`);
@@ -121,8 +123,13 @@ class GetAllData {
       // Increment downloaded counter only if it was ok
       this.counters.downloaded++;
 
-      return parsed
+    }
 
+    try {
+      return request.parse( data, this.parseDataErrors );
+    } catch(err) {
+      console.error(err);
+      throw new Error(`Error parsing the results: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
- Allow to disable cache reading from constructor (debugging option).
- Allow to disable cache reading from command line.
- Correctly detect and inform requestList parse errors.
- Send to socket which requests are needed to do a complete connection restart: the forced ones.
- Socket:
  - Save initial requests in an internal array to do a complete reconnection when needed.
  - Detect connection fatal error and do a complete reconnection.
  - Split/refactor/abstract `consume` logic, with no interface change: more readable, less repetitive, more maintainable